### PR TITLE
remove memory leak in animation handling

### DIFF
--- a/src/TextWatch.c
+++ b/src/TextWatch.c
@@ -29,10 +29,9 @@ static char line3Str[2][BUFFER_SIZE];
 // Animation handler
 static void animationStoppedHandler(struct Animation *animation, bool finished, void *context)
 {
-	Layer *textLayer = text_layer_get_layer((TextLayer *)context);
-	GRect rect = layer_get_frame(textLayer);
-	rect.origin.x = 144;
-	layer_set_frame(textLayer, rect);
+	//unless we destroy the animation the memory leak from continued property_animatin_create_layer_frame will kill us
+	Line *line = (Line*)context);
+	property_animation_destroy(line->currentAnimation);
 }
 
 // Animate line
@@ -40,7 +39,9 @@ static void makeAnimationsForLayers(Line *line, TextLayer *current, TextLayer *n
 {
 	GRect fromRect = layer_get_frame(text_layer_get_layer(next));
 	GRect toRect = fromRect;
-	toRect.origin.x -= 144;
+	//move the animation math here instead of the Animation handler
+	toRect.origin.x = 0;
+	fromRect.origin.x= 144;
 	
 	line->nextAnimation = property_animation_create_layer_frame(text_layer_get_layer(next), &fromRect, &toRect);
 	animation_set_duration((Animation *)line->nextAnimation, 400);
@@ -49,7 +50,9 @@ static void makeAnimationsForLayers(Line *line, TextLayer *current, TextLayer *n
 	
 	GRect fromRect2 = layer_get_frame(text_layer_get_layer(current));
 	GRect toRect2 = fromRect2;
-	toRect2.origin.x -= 144;
+	//move the animation math here instead of the Animation handler
+	toRect2.origin.x = 0;
+	fronRect2.origin.x = 144
 	
 	line->currentAnimation = property_animation_create_layer_frame(text_layer_get_layer(current), &fromRect2, &toRect2);
 	animation_set_duration((Animation *)line->currentAnimation, 400);

--- a/src/TextWatch.c
+++ b/src/TextWatch.c
@@ -30,7 +30,7 @@ static char line3Str[2][BUFFER_SIZE];
 static void animationStoppedHandler(struct Animation *animation, bool finished, void *context)
 {
 	//unless we destroy the animation the memory leak from continued property_animatin_create_layer_frame will kill us
-	Line *line = (Line*)context);
+	Line *line = ((Line*)context);
 	property_animation_destroy(line->currentAnimation);
 }
 
@@ -52,7 +52,7 @@ static void makeAnimationsForLayers(Line *line, TextLayer *current, TextLayer *n
 	GRect toRect2 = fromRect2;
 	//move the animation math here instead of the Animation handler
 	toRect2.origin.x = 0;
-	fronRect2.origin.x = 144
+	fromRect2.origin.x = 144;
 	
 	line->currentAnimation = property_animation_create_layer_frame(text_layer_get_layer(current), &fromRect2, &toRect2);
 	animation_set_duration((Animation *)line->currentAnimation, 400);

--- a/src/TextWatch.c
+++ b/src/TextWatch.c
@@ -30,7 +30,7 @@ static char line3Str[2][BUFFER_SIZE];
 static void animationStoppedHandler(struct Animation *animation, bool finished, void *context)
 {
 	//unless we destroy the animation the memory leak from continued property_animatin_create_layer_frame will kill us
-	Line *line = ((Line*)context);
+	Line *line = (Line*)context;
 	property_animation_destroy(line->currentAnimation);
 }
 
@@ -51,8 +51,8 @@ static void makeAnimationsForLayers(Line *line, TextLayer *current, TextLayer *n
 	GRect fromRect2 = layer_get_frame(text_layer_get_layer(current));
 	GRect toRect2 = fromRect2;
 	//move the animation math here instead of the Animation handler
-	toRect2.origin.x = 0;
-	fromRect2.origin.x = 144;
+	toRect2.origin.x = -144;
+	fromRect2.origin.x = 0;
 	
 	line->currentAnimation = property_animation_create_layer_frame(text_layer_get_layer(current), &fromRect2, &toRect2);
 	animation_set_duration((Animation *)line->currentAnimation, 400);
@@ -60,7 +60,7 @@ static void makeAnimationsForLayers(Line *line, TextLayer *current, TextLayer *n
 	
 	animation_set_handlers((Animation *)line->currentAnimation, (AnimationHandlers) {
 		.stopped = (AnimationStoppedHandler)animationStoppedHandler
-	}, current);
+	}, line);
 	
 	animation_schedule((Animation *)line->currentAnimation);
 }

--- a/src/TextWatch.c
+++ b/src/TextWatch.c
@@ -26,6 +26,8 @@ static char line1Str[2][BUFFER_SIZE];
 static char line2Str[2][BUFFER_SIZE];
 static char line3Str[2][BUFFER_SIZE];
 
+static int pauseAnimation;
+
 // Animation handler
 static void animationStoppedHandler(struct Animation *animation, bool finished, void *context)
 {
@@ -38,6 +40,7 @@ static void animationStoppedHandler(struct Animation *animation, bool finished, 
 // Animate line
 static void makeAnimationsForLayers(Line *line, TextLayer *current, TextLayer *next)
 {
+	if (pauseAnimation){return;}
 	GRect fromRect = layer_get_frame(text_layer_get_layer(next));
 	GRect toRect = fromRect;
 	toRect.origin.x -= 144;
@@ -188,7 +191,17 @@ static void handle_minute_tick(struct tm *tick_time, TimeUnits units_changed) {
   display_time(tick_time);
 }
 
+void focus_handler(bool in_focus) {
+  if (in_focus) {
+    pauseAnimation = 0;
+    display_time(t);
+  } else {
+    pauseAnimation = 1;
+  }
+}
+
 static void init() {
+  pauseAnimation = 0;
   window = window_create();
   window_stack_push(window, true);
   window_set_background_color(window, GColorBlack);
@@ -235,6 +248,7 @@ static void init() {
 	#endif
 
   tick_timer_service_subscribe(MINUTE_UNIT, handle_minute_tick);
+  app_focus_service_subscribe(focus_handler);
 }
 
 static void deinit() {

--- a/src/TextWatch.c
+++ b/src/TextWatch.c
@@ -26,8 +26,6 @@ static char line1Str[2][BUFFER_SIZE];
 static char line2Str[2][BUFFER_SIZE];
 static char line3Str[2][BUFFER_SIZE];
 
-static int pauseAnimation;
-
 // Animation handler
 static void animationStoppedHandler(struct Animation *animation, bool finished, void *context)
 {
@@ -40,7 +38,6 @@ static void animationStoppedHandler(struct Animation *animation, bool finished, 
 // Animate line
 static void makeAnimationsForLayers(Line *line, TextLayer *current, TextLayer *next)
 {
-	if (pauseAnimation){return;}
 	GRect fromRect = layer_get_frame(text_layer_get_layer(next));
 	GRect toRect = fromRect;
 	toRect.origin.x -= 144;
@@ -191,17 +188,7 @@ static void handle_minute_tick(struct tm *tick_time, TimeUnits units_changed) {
   display_time(tick_time);
 }
 
-void focus_handler(bool in_focus) {
-  if (in_focus) {
-    pauseAnimation = 0;
-    display_time(t);
-  } else {
-    pauseAnimation = 1;
-  }
-}
-
 static void init() {
-  pauseAnimation = 0;
   window = window_create();
   window_stack_push(window, true);
   window_set_background_color(window, GColorBlack);
@@ -248,7 +235,6 @@ static void init() {
 	#endif
 
   tick_timer_service_subscribe(MINUTE_UNIT, handle_minute_tick);
-  app_focus_service_subscribe(focus_handler);
 }
 
 static void deinit() {


### PR DESCRIPTION
a call to property_animation_create_layer_frame() in makeAnimationsForLayers() did not have a corresponding property_animation_destroy() in animationStoppedHandler() and was leaking memory.

I based a watchface on this code where my hour line changes on every handle_minute_tick and was seeing application crashes several times a day.

I've noticed the same behavior in TextWatch_es as well.  

This should fix the issue.
